### PR TITLE
✨ feat: AWS Secrets Manager Makeターゲット追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ PROJECT_NAME=vecr-garage
 CONTAINER_NAME=${PROJECT_NAME}
 NETWORK_NAME=${PROJECT_NAME}-network
 
+# AWS Profile Configuration
+AWS_PROFILE=your_aws_profile_name
+AWS_ENVIRONMENT=dev
+
 # Database Configuration
 MEMBER_DB_NAME=member_db
 MEMBER_DB_USER=testuser

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,10 @@ ADMIN_USERNAME=Admin
 ADMIN_PASSWORD=SamplePassword
 SECRET_KEY=vecr-garage-secret-key-development-only-2025
 
+# AWS設定
+AWS_PROFILE=your-aws-profile
+AWS_ENVIRONMENT=dev
+
 # Claude API設定
 ANTHROPIC_API_KEY=sk-ant-xxxxx
 ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
@@ -448,9 +452,11 @@ make secrets-audit             # ベースライン監査
 - [x] Discord Bot Timesモード実装（1日1回自動投稿＋APScheduler統合）
 - [x] Discord Bot Times Modeテスト機能実装（本番/テストモード切り替え）
 - [x] CI/CD Docker化システム実装（完全コンテナベース実行）
+- [x] AWS Secrets Manager Makeターゲット追加（ホスト側からの機密情報取得基盤）
 
 ### 実装予定
 
+- [ ] AWS Secrets Managerからコンテナへの機密情報注入
 - [ ] Discord Bot Times Mode話題管理の改善（データベース化、カテゴリ分類等）
 - [ ] Discord Bot会話履歴管理の改善（DynamoDB統合、トピック検出等）
 - [ ] file_uri-based UPSERT処理（本格実装）
@@ -461,7 +467,6 @@ make secrets-audit             # ベースライン監査
 - [ ] Discord Bot機能拡張（複数Bot、スレッド対応、コンテキスト保持）
 - [ ] LLM連携機能の強化（メンバープロフィールとの統合）
 - [ ] Discord通知機能の拡張（定期通知、エラー通知、リッチエンベッド等）
-- [ ] AWS Secrets Managerへの移行
 - [ ] 本番環境用の設定追加
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ include makefiles/backend-db-registration.mk
 include makefiles/backend-llm-response.mk
 include makefiles/ci.mk
 include makefiles/secrets.mk
+include makefiles/aws.mk
 
 # 便利なエイリアスと後方互換性
 s3-cp-samples: samples-copy ## Copy normal sample files to MinIO storage

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ make test-integration
 - `config/discord_webhooks.json`は`.gitignore`で保護
 - `.envrc`も`.gitignore`で保護
 - コンテナにはファイルをマウントせず、環境変数として渡す
-- AWS Secrets Managerへの移行準備完了
+- AWS Secrets Manager統合済み（ホスト側からの機密情報取得）
 
 **統合テスト:**
 
@@ -321,6 +321,50 @@ $ make claude-prompt PROMPT="Pythonで素数判定する関数を書いてくだ
 
 - APIキーは`.env`で管理（.gitignore保護）
 - コンテナに環境変数として渡される
+- AWS Secrets Managerからの取得も可能（下記参照）
+
+#### AWS Secrets Manager連携
+
+AWS Secrets Managerから機密情報を取得するコマンドを提供しています。
+
+**前提条件:**
+
+```bash
+# 1. AWS CLIの設定（プロファイル作成済みであること）
+aws configure --profile your-profile-name
+
+# 2. .envファイルにAWS設定を追加
+AWS_PROFILE=your-profile-name
+AWS_ENVIRONMENT=dev
+```
+
+**使用可能なコマンド:**
+
+```bash
+# シークレットのキー一覧を表示
+make aws-secret-list
+
+# 特定のキーの値を取得
+make aws-secret-get KEY=anthropic_api_key
+
+# 別のシークレット名を指定（デフォルト: lambda-secrets）
+make aws-secret-list SECRET=app-secrets
+make aws-secret-get KEY=some_key SECRET=app-secrets
+
+# プロジェクトの全シークレット一覧
+make aws-secret-list-all
+```
+
+**シークレット命名規則:**
+
+- 形式: `{PROJECT_NAME}-{AWS_ENVIRONMENT}-{SECRET_NAME}`
+- 例: `vecr-garage-dev-lambda-secrets`
+
+**セキュリティ:**
+
+- AWS IAMによるアクセス制御
+- プロファイルベースの認証（共有クレデンシャル不要）
+- 環境別（dev/staging/prod）のシークレット分離
 
 #### Discord Bot統合
 

--- a/makefiles/aws.mk
+++ b/makefiles/aws.mk
@@ -1,0 +1,46 @@
+# description: AWS CLIのMakefile
+
+# ------------------------------------------------------------
+# Environment Check
+# ------------------------------------------------------------
+
+check-env: ## Check required AWS environment variables
+	@if [ -z "$(AWS_PROFILE)" ]; then \
+		echo "Error: AWS_PROFILE is not set"; \
+		exit 1; \
+	fi
+	@if [ -z "$(PROJECT_NAME)" ]; then \
+		echo "Error: PROJECT_NAME is not set"; \
+		exit 1; \
+	fi
+	@if [ -z "$(AWS_ENVIRONMENT)" ]; then \
+		echo "Error: AWS_ENVIRONMENT is not set"; \
+		exit 1; \
+	fi
+
+# ------------------------------------------------------------
+# Secrets Manager
+# ------------------------------------------------------------
+
+aws-secret-get: check-env ## Get a secret value by key. Usage: make secret-get KEY=key_name
+	@if [ -z "$(KEY)" ]; then \
+		echo "Error: KEY is required. Usage: make secret-get KEY=<key_name> [SECRET=lambda-secrets|app-secrets]"; \
+		exit 1; \
+	fi
+	@SECRET_NAME=$${SECRET:-lambda-secrets}; \
+	AWS_PROFILE=$(AWS_PROFILE) aws secretsmanager get-secret-value \
+		--secret-id $(PROJECT_NAME)-$(AWS_ENVIRONMENT)-$$SECRET_NAME \
+		--query 'SecretString' --output text | jq -r ".$(KEY)"
+
+aws-secret-list: check-env ## List all secret keys. Usage: make secret-list [SECRET=lambda-secrets]
+	@SECRET_NAME=$${SECRET:-lambda-secrets}; \
+	echo "Keys in $(PROJECT_NAME)-$(AWS_ENVIRONMENT)-$$SECRET_NAME:"; \
+	AWS_PROFILE=$(AWS_PROFILE) aws secretsmanager get-secret-value \
+		--secret-id $(PROJECT_NAME)-$(AWS_ENVIRONMENT)-$$SECRET_NAME \
+		--query 'SecretString' --output text | jq -r 'keys[]'
+
+aws-secret-list-all: check-env ## List all secrets in Secrets Manager for this PROJECT_NAME
+	@echo "Secrets for $(PROJECT_NAME)-$(AWS_ENVIRONMENT):"
+	@AWS_PROFILE=$(AWS_PROFILE) aws secretsmanager list-secrets \
+		--filter Key=name,Values=$(PROJECT_NAME)-$(AWS_ENVIRONMENT) \
+		--query 'SecretList[].Name' --output text | tr '\t' '\n'


### PR DESCRIPTION
## Summary

- AWS Secrets Managerから機密情報を取得するMakeターゲットを追加
- ホスト側からの機密情報取得基盤を整備（コンテナへの注入は次ステップ）
- 環境変数`AWS_PROFILE`/`AWS_ENVIRONMENT`による柔軟な環境切り替えをサポート

## 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `makefiles/aws.mk` | 新規作成: `check-env`, `aws-secret-get`, `aws-secret-list`, `aws-secret-list-all` |
| `Makefile` | `aws.mk`のinclude追加 |
| `.env.example` | `AWS_PROFILE`, `AWS_ENVIRONMENT`追加 |
| `CLAUDE.md` | 環境変数・実装完了・今後の予定を更新 |
| `README.md` | AWS Secrets Manager連携セクション追加 |

## 使用方法

1. `.env.example`を参照して`.env`に実際の`AWS_PROFILE`を記入してください

2. コマンド実行:

```bash
# シークレットのキー一覧を表示
make aws-secret-list

# 特定のキーの値を取得
make aws-secret-get KEY=anthropic_api_key

# 別のシークレット名を指定
make aws-secret-list SECRET=app-secrets

# プロジェクトの全シークレット一覧
make aws-secret-list-all
```

## シークレット命名規則

- 形式: `{PROJECT_NAME}-{AWS_ENVIRONMENT}-{SECRET_NAME}`
- 例: `vecr-garage-dev-lambda-secrets`

## Test plan

- [x] `make aws-secret-list` でキー一覧取得を確認
- [x] `make aws-secret-get KEY=open_router_api_key` で値取得を確認
- [x] pre-commitチェック通過

## レビュー依頼事項

以下の動作確認をお願いします:

```bash
$ make aws-secret-get KEY=anthropic_api_key
sk-ant-api03-xxxxxxxx
```

引数`KEY`にキー名を入れることで実際の値を取得できるか確認してください。

## 今後の予定

- [ ] AWS Secrets Managerからコンテナへの機密情報注入

🤖 Generated with [Claude Code](https://claude.com/claude-code)